### PR TITLE
Prefixing options instance variable on logger and csv modules

### DIFF
--- a/lib/data_migrater/csv.rb
+++ b/lib/data_migrater/csv.rb
@@ -36,11 +36,11 @@ module DataMigrater
 
     module ClassMethods
       def data_csv(options = {})
-        @options = options
+        @csv_options = options
       end
 
       def csv_options
-        @options || {}
+        @csv_options || {}
       end
     end
   end

--- a/lib/data_migrater/logger.rb
+++ b/lib/data_migrater/logger.rb
@@ -44,11 +44,11 @@ module DataMigrater
 
     module ClassMethods
       def data_logger(options = {})
-        @options = options
+        @logger_options = options
       end
 
       def logger_options
-        @options || {}
+        @logger_options || {}
       end
     end
   end


### PR DESCRIPTION
The options are override when you set both csv and logger data.