### PR TITLE
Rails 5.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,39 +2,39 @@ PATH
   remote: .
   specs:
     data_migrater (0.6.0)
-      activerecord (>= 4.1, < 5.2)
+      activerecord (>= 4.1, < 6)
       aws-sdk-s3 (~> 1)
-      railties (>= 4.1, < 5.2)
+      railties (>= 4.1, < 6)
       smarter_csv (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.1.7)
-      actionview (= 5.1.7)
-      activesupport (= 5.1.7)
+    actionpack (5.2.3)
+      actionview (= 5.2.3)
+      activesupport (= 5.2.3)
       rack (~> 2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.1.7)
-      activesupport (= 5.1.7)
+    actionview (5.2.3)
+      activesupport (= 5.2.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activemodel (5.1.7)
-      activesupport (= 5.1.7)
-    activerecord (5.1.7)
-      activemodel (= 5.1.7)
-      activesupport (= 5.1.7)
-      arel (~> 8.0)
-    activesupport (5.1.7)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
+      arel (>= 9.0)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (8.0.0)
+    arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.158.0)
@@ -88,12 +88,12 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    railties (5.1.7)
-      actionpack (= 5.1.7)
-      activesupport (= 5.1.7)
+    railties (5.2.3)
+      actionpack (= 5.2.3)
+      activesupport (= 5.2.3)
       method_source
       rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
+      thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
     rspec-core (3.8.0)
@@ -124,7 +124,7 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     smarter_csv (1.2.6)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -139,7 +139,7 @@ DEPENDENCIES
   pry-byebug
   rspec-rails
   rubocop-rspec
-  sqlite3 (~> 1.3.6)
+  sqlite3
 
 BUNDLED WITH
    1.17.3

--- a/data_migrater.gemspec
+++ b/data_migrater.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
   spec.test_files  = Dir['spec/**/*']
   spec.version     = DataMigrater::VERSION
 
-  spec.add_dependency 'activerecord', '>= 4.1', '< 5.2'
+  spec.add_dependency 'activerecord', '>= 4.1', '< 6'
   spec.add_dependency 'aws-sdk-s3',   '~> 1'
-  spec.add_dependency 'railties',     '>= 4.1', '< 5.2'
+  spec.add_dependency 'railties',     '>= 4.1', '< 6'
   spec.add_dependency 'smarter_csv',  '~> 1.1'
 
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/spec/migrater_spec.rb
+++ b/spec/migrater_spec.rb
@@ -102,10 +102,6 @@ describe DataMigrater::Migrator do
       end
 
       context 'executed' do
-        before do
-          allow_any_instance_of(ActiveRecord::Migrator).to receive(:pending_migrations) { [] }
-        end
-
         it 'runs the data migrations' do
           expect(data_migration).to receive :execute
 


### PR DESCRIPTION
The method `ActiveRecord::Migrator.open` became private in Rails 5.2.

It works with Rails 4.2 also.